### PR TITLE
更新

### DIFF
--- a/kscore/serialize.py
+++ b/kscore/serialize.py
@@ -194,6 +194,10 @@ class QuerySerializer(Serializer):
                 'X-Version': operation_model.metadata['apiVersion'],
             }
         )
+
+        if 'requestUri' in operation_model.http:
+            serialized['url_path'] = operation_model.http['requestUri']
+
         body_params = self.MAP_TYPE()
 
         if shape is not None:
@@ -363,6 +367,9 @@ class CustomBodySerializer(QueryAcceptJsonSerializer):
                 'X-Version': operation_model.metadata['apiVersion'],
             }
         )
+        if 'requestUri' in operation_model.http:
+            serialized['url_path'] = operation_model.http['requestUri']
+
         body_params = self.MAP_TYPE()
         custom_body = None
         if 'Body' in parameters:
@@ -377,7 +384,6 @@ class CustomBodySerializer(QueryAcceptJsonSerializer):
         if body is not None:
             serialized['body'] = json.dumps(body).encode(self.DEFAULT_ENCODING)
         serialized['query_string'] = data
-        print serialized
         return serialized
 
 
@@ -394,6 +400,9 @@ class JSONSerializer(Serializer):
         serialized = self._create_default_request()
         serialized['method'] = operation_model.http.get('method',
                                                         self.DEFAULT_METHOD)
+
+        if 'requestUri' in operation_model.http:
+            serialized['url_path'] = operation_model.http['requestUri']
 
         serialized['query_string'] = self.MAP_TYPE()
 
@@ -497,6 +506,10 @@ class BaseRestSerializer(Serializer):
 
     def serialize_to_request(self, parameters, operation_model):
         serialized = self._create_default_request()
+        serialized['headers'] = {
+            'X-Action': operation_model.name,
+            'X-Version': operation_model.metadata['apiVersion']
+        }
         serialized['method'] = operation_model.http.get('method',
                                                         self.DEFAULT_METHOD)
         shape = operation_model.input_shape


### PR DESCRIPTION
1. json、query-json、kcs、query、json2协议对requestUri参数的支持，通过各服务的方法内requestUri参数，支持在url自定义path。
2. 对rest-json、rest-xml协议headers内X-Version、X-Action的支持。