### PR TITLE
KEC服务SDK支持

### DIFF
--- a/kscore/data/kec/2016-03-04/service-2.yaml
+++ b/kscore/data/kec/2016-03-04/service-2.yaml
@@ -10,47 +10,79 @@ metadata:
   protocol: query-json
 
 operations:
-  RegionList:
-    name: RegionList
+
+  RunInstances:
     http:
       method: GET
-    input:
-      shape: Empty
+
+  TerminateInstances:
+    http:
+      method: GET
+
+  StartInstances:
+    http:
+      method: GET
+
+  StopInstances:
+    http:
+      method: GET
+
+  RebootInstances:
+    http:
+      method: GET
+
+  MonitorInstances:
+    http:
+      method: GET
+
+  UnmonitorInstances:
+    http:
+      method: GET
+
+  ModifyInstanceType:
+    http:
+      method: GET
+
+  ModifyInstanceImage:
+    http:
+      method: GET
+
+  ModifyInstanceAttribute:
+    http:
+      method: GET
+
+  DescribeInstanceVnc:
+    http:
+      method: GET
+
+  AttachNetworkInterface:
+    http:
+      method: GET
 
   DescribeInstances:
-    name: DescribeInstances
     http:
       method: GET
-shapes:
-  Id:
-    type: string #list/map/structure
 
-  Bool:
-    type: bool
+  ModifyNetworkInterfaceAttribute:
+    http:
+      method: GET
 
-  Int:
-    type: int
+  DetachNetworkInterface:
+    http:
+      method: GET
 
-  DataTime:
-    type: timestamp
+  CreateImage:
+    http:
+      method: GET
 
-  Empty:
-    type: structure
-    members: {}
-    documentation: ""
+  DescribeImages:
+    http:
+      method: GET
 
-  NonEmptyString:
-    type: string
-    min: 1
+  RemoveImages:
+    http:
+      method: GET
 
-  Message:
-    type: string
-
-  InstanceId:
-    type: structure
-    required:
-    - id
-    members:
-      id:
-        shape: Id
-    documentation: ""
+  ModifyImageAttribute:
+    http:
+      method: GET

--- a/kscore/serialize.py
+++ b/kscore/serialize.py
@@ -200,6 +200,9 @@ class QuerySerializer(Serializer):
 
         body_params = self.MAP_TYPE()
 
+        body_params['Action'] = operation_model.name
+        body_params['Version'] = operation_model.metadata['apiVersion']
+
         if shape is not None:
             self._serialize(body_params, parameters, shape)
         else:


### PR DESCRIPTION
1、 KEC 方法支持， shanghai 2 、 beijing 6.
2、query协议的Action、Version同步至URL、或者body内，支持KEC方法。