### PR TITLE
setup.py long_description update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     name='ksc-sdk-python',
     version=kscore.__version__,
     description='Low-level, data-driven core of ksc.',
-    long_description=open('README.rst').read(),
+    long_description='A low-level interface to a growing number of KSC Web Services.',
     author=AUTHOR,
     url='https://github.com/liuyichen/kscore',
     author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
修复 #39 导致 python 2.x 无法安装问题。
原因：
  2.x版本open不支持encoding参数。
解决方法：
  替换原README.rst读取内容为默认字符串。
注：如有必要可做版本判断，2.x 使用 codecs.open或io.open 替代。