### PR TITLE
云主机用例修正及针对500状态码的重试机制移除

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,9 +256,3 @@ BUG FIXED 问题修正
 ::
 
     yum install python-devel
-
---------------------
-Contact Information
---------------------
-
-服 务 群 号: 580681922

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,6 @@ A low-level interface to a growing number of KSC Web Services.
 Install 安装
 ----------------
 
-+ pip 安装
-    + pip install ksc-sdk-python
-
 + github 安装
     + 通过 `GitHub <https://github.com/KscSDK/ksc-sdk-python>`__ 下载
     + 通过命令 python setup.py install 安装
@@ -21,7 +18,7 @@ Config 配置
 
 + 申请安全凭证：
 
-    在第一次使用云API之前，用户首先需要在金山云控制台IAM服务申请安全凭证，安全凭证包括access_key_id和secret_access_key,access_key_id 是用于标识API调用者的身份，secret_access_key是用于加密签名字符串和服务器端验证签名字符串的密钥。secret_access_key 必须严格保管，避免泄露。
+    在第一次使用云API之前，用户首先需要在金山云控制台申请安全凭证，安全凭证包括access_key_id和secret_access_key,access_key_id 是用于标识API调用者的身份，secret_access_key是用于加密签名字符串和服务器端验证签名字符串的密钥。secret_access_key 必须严格保管，避免泄露。
 
 + 通过文件配置及管理密钥，参考examples内示例：
 

--- a/examples/kec.py
+++ b/examples/kec.py
@@ -5,12 +5,22 @@ from kscore.session import get_session
 if __name__ == "__main__":
     s = get_session()
 
-    client = s.create_client("kec", "cn-beijing-6", use_ssl=True)
+    client = s.create_client("kec", "cn-beijing-6", use_ssl=False)
 
-    print client.describe_instances()
+    # https://docs.ksyun.com/read/latest/52/_book/oaDescribeInstances.html
+    client.describe_instances()
 
-#    client.create_user(UserName="test22", RealName=u"刘一辰")
+    # https://docs.ksyun.com/read/latest/52/_book/oaRunInstances.html
+    client.run_instances(
+        MaxCount=50, MinCount=20, ImageId="3f3bddcf-4982-4ab4-a63d-795e8d74e9d5",
+        SubnetId="f1bd236b-7fd3-44d3-aef9-2d673a65466e", InstancePassword="Ksyun2017",
+        SecurityGroupId="2f43a9e4-1a3c-448e-b661-efa6d04b82fc", DataDiskGb=50, ChargeType="Monthly",
+        InstanceType="C1.1A", PurchaseTime=1, InstanceName="test", InstanceNameSuffix="1")
+    
+    # https://docs.ksyun.com/read/latest/52/_book/oaTerminateInstances.html
+    instances = ["2f43a9e4-1a3c-448e-b661-efa6d04b82fc", "2f43a9e4-1a3c-448e-b661-efa6d04b82fc"]
 
-#    client.update_user(UserName="test22",)
+    instances = dict(("InstanceId.{}".format(index), instance) for index, instance in enumerate(instances, 1))
 
-#    client.delete_user(UserName="test22")
+    client.terminate_instances(**instances)
+

--- a/kscore/data/_retry.yaml
+++ b/kscore/data/_retry.yaml
@@ -18,10 +18,6 @@ definitions:
     applies_when:
       socket_errors:
       - GENERAL_CONNECTION_ERROR
-  general_server_error:
-    applies_when:
-      response:
-        http_status_code: 500
   bad_gateway:
     applies_when:
       response:
@@ -44,8 +40,6 @@ retry:
     policies:
       general_socket_errors:
         "$ref": general_socket_errors
-      general_server_error:
-        "$ref": general_server_error
       service_unavailable:
         "$ref": service_unavailable
       limit_exceeded:


### PR DESCRIPTION
云主机用例修正

- 添加查询、创建、删除云主机的用例。

针对500状态码的重试机制移除

- 原retry机制在data/_retry.yaml下配置了针对500状态码的重试机制，与支付失败的错误状态冲突，移除修复。