### PR TITLE
云监控修改错误返回

### DIFF
--- a/kscore/client.py
+++ b/kscore/client.py
@@ -527,7 +527,9 @@ class BaseClient(object):
             http_response=http, parsed=parsed_response,
             model=operation_model, context=request_context
         )
-
+        if operation_name == 'ListMetrics' or operation_name == 'GetMetricStatistics':
+            return parsed_response
+        
         if http.status_code >= 300:
             raise ClientError(parsed_response, operation_name)
         else:


### PR DESCRIPTION
云监控大于300的错误码，不抛异常，直接返回错误